### PR TITLE
[design] 설계 품목 ItemCard 애니메이션 수정

### DIFF
--- a/src/components/ItemCard.jsx
+++ b/src/components/ItemCard.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types'
 export default function ItemCard({ src, title, content }) {
   return (
     <div className='relative w-full h-full flex items-center justify-center rounded-lg overflow-hidden group lg:h-full md:h-[400px] sm:h-[300px] transition-all duration-[800ms]'>
-      <div className='absolute inset-0 bg-gradient-to-t from-transparent to-black opacity-60 transition-all duration-300'></div>
+      <div className='absolute inset-0 bg-gradient-to-t from-transparent to-black opacity-60 transition-all duration-[800ms]'></div>
 
       <img
         src={src}
         alt={title}
-        className='w-full h-full object-cover'
+        className='w-full h-full object-cover transition-all duration-[800ms] group-hover:scale-110'
         loading='lazy'
         width='600'
         height='400'
@@ -16,7 +16,7 @@ export default function ItemCard({ src, title, content }) {
       <div
         className={`absolute z-10 w-full h-full px-4 lg:py-[10%] py-[8%] flex flex-col gap-2 group-hover:justify-center items-center text-white transition-all duration-[800ms]`}
       >
-        <span className='font-bold md:text-[20px] sm:text-[18px] text-[15px] transition-all duration-[800ms]'>
+        <span className='font-bold md:text-[20px] sm:text-[18px] text-[15px] transition-all duration-[800ms] group-hover:text-[24px]'>
           {title}
         </span>
         <span


### PR DESCRIPTION
## Summary
<!-- 한 줄 설명 -->

## Description
<!-- - 어떤 코드가 추가/변경 됐는지 -->

설계 품목의 내용이 담긴 ItemCard.jsx 수정
- 모든 전환 효과의 지속 시간을 800ms로 통일
- 이미지에 group-hover:scale-110 효과 추가
- 제목 텍스트에 호버 시 크기가 커지는 효과 추가 (group-hover:text-[24px])
- 그라데이션과 오버레이의 전환 효과를 부드럽게 조정

## Screenshots
<!-- 실행 결과 스크린샷 -->

| Before | After |
| :-------------: |  :-------------: |
| ![before](https://github.com/user-attachments/assets/42d64017-3f20-47c7-80d5-a64b97d54063) | ![after](https://github.com/user-attachments/assets/4cdf96e1-2372-416d-943a-e6ccaa8cdd38) |


## Test Checklist
<!-- - [ ] 테스트할 사람이 어떤 것을 확인하면 좋을지 -->
- [ ] 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 배경 그라데이션 오버레이, 이미지 확대, 제목 글자 크기 변화 등 애니메이션 효과의 전환 시간이 800ms로 통일되어 더욱 부드러운 인터랙션을 제공합니다.
  - 카드에 마우스를 올렸을 때 이미지가 자연스럽게 확대되고, 제목 글씨가 커지는 시각적 효과가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->